### PR TITLE
Update Minecraft to 1.20.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.3-SNAPSHOT'
+	id 'fabric-loom' version '1.5-SNAPSHOT'
 	id "com.modrinth.minotaur" version "2.+"
 	id 'maven-publish'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,9 +4,10 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.20.1
-yarn_mappings=1.20.1+build.10
-loader_version=0.14.22
+minecraft_version=1.20.4
+yarn_mappings=1.20.4+build.3
+loader_version=0.15.6
+
 
 # Mod Properties
 mod_version=1.1.0
@@ -14,5 +15,5 @@ maven_group=net.luckius
 archives_base_name=luckius_mortar
 
 # Dependencies
-fabric_version=0.87.0+1.20.1
-emi_version=1.0.19+1.20.1
+fabric_version=0.95.4+1.20.4
+emi_version=1.1.0+1.20.4

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/net/luckius/luckius_mortar/emi/LuckiusMortarEmiPlugin.java
+++ b/src/main/java/net/luckius/luckius_mortar/emi/LuckiusMortarEmiPlugin.java
@@ -3,12 +3,12 @@ package net.luckius.luckius_mortar.emi;
 import dev.emi.emi.api.EmiPlugin;
 import dev.emi.emi.api.EmiRegistry;
 import dev.emi.emi.api.recipe.EmiRecipeCategory;
-import dev.emi.emi.api.render.EmiTexture;
 import dev.emi.emi.api.stack.EmiStack;
 import net.luckius.luckius_mortar.LuckiusMortar;
 import net.luckius.luckius_mortar.item.ModItems;
 import net.luckius.luckius_mortar.recipe.ModRecipes;
 import net.luckius.luckius_mortar.recipe.mortar.MortarRecipe;
+import net.minecraft.recipe.RecipeEntry;
 import net.minecraft.recipe.RecipeManager;
 import net.minecraft.util.Identifier;
 
@@ -28,7 +28,7 @@ public class LuckiusMortarEmiPlugin implements EmiPlugin {
 
         RecipeManager manager = registry.getRecipeManager();
 
-        for (MortarRecipe recipe : manager.listAllOfType(ModRecipes.MORTAR_RECIPE)) {
+        for (RecipeEntry<MortarRecipe> recipe : manager.listAllOfType(ModRecipes.MORTAR_RECIPE)) {
             registry.addRecipe(new MortarEmiRecipe(recipe));
         }
     }

--- a/src/main/java/net/luckius/luckius_mortar/emi/MortarEmiRecipe.java
+++ b/src/main/java/net/luckius/luckius_mortar/emi/MortarEmiRecipe.java
@@ -6,13 +6,14 @@ import dev.emi.emi.api.stack.EmiIngredient;
 import dev.emi.emi.api.stack.EmiStack;
 import dev.emi.emi.api.widget.WidgetHolder;
 import net.luckius.luckius_mortar.recipe.mortar.MortarRecipe;
+import net.minecraft.recipe.RecipeEntry;
 
 public class MortarEmiRecipe extends BasicEmiRecipe {
 
-    public MortarEmiRecipe(MortarRecipe recipe) {
-        super(LuckiusMortarEmiPlugin.MORTAR_RECIPE_CATEGORY, recipe.getId(), 70, 18);
-        this.inputs.add(EmiIngredient.of(recipe.getInput()));
-        this.outputs.add(EmiStack.of(recipe.getOutput(null)));
+    public MortarEmiRecipe(RecipeEntry<MortarRecipe> recipe) {
+        super(LuckiusMortarEmiPlugin.MORTAR_RECIPE_CATEGORY, recipe.id(), 70, 18);
+        this.inputs.add(EmiIngredient.of(recipe.value().getInput()));
+        this.outputs.add(EmiStack.of(recipe.value().getResult(null)));
     }
 
     @Override

--- a/src/main/java/net/luckius/luckius_mortar/item/custom/MortarItem.java
+++ b/src/main/java/net/luckius/luckius_mortar/item/custom/MortarItem.java
@@ -8,9 +8,9 @@ import net.minecraft.inventory.SimpleInventory;
 import net.minecraft.inventory.StackReference;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.recipe.RecipeEntry;
 import net.minecraft.screen.slot.Slot;
 import net.minecraft.sound.SoundCategory;
-import net.minecraft.sound.SoundEvents;
 import net.minecraft.util.ClickType;
 import net.minecraft.world.World;
 
@@ -35,7 +35,7 @@ public class MortarItem extends Item {
 
 			SimpleInventory inventory = new SimpleInventory(1);
 			inventory.setStack(0, new ItemStack(input.getItem(), 1));
-			Optional<MortarRecipe> match = world.getRecipeManager().getFirstMatch(ModRecipes.MORTAR_RECIPE, inventory, world);
+			Optional<MortarRecipe> match = world.getRecipeManager().getFirstMatch(ModRecipes.MORTAR_RECIPE, inventory, world).map(RecipeEntry::value);
 
 			if (match.isEmpty()) return false; // Check if a recipe was found
 
@@ -43,7 +43,7 @@ public class MortarItem extends Item {
 
 			MortarRecipe recipe = match.get();
 
-			ItemStack output = recipe.getOutput(null).copy();
+			ItemStack output = recipe.getResult(null).copy();
 			if (!player.getInventory().insertStack(output)) {
 				player.dropStack(output); // Drop the remains
 			}

--- a/src/main/java/net/luckius/luckius_mortar/recipe/mortar/MortarRecipe.java
+++ b/src/main/java/net/luckius/luckius_mortar/recipe/mortar/MortarRecipe.java
@@ -8,18 +8,14 @@ import net.minecraft.recipe.Recipe;
 import net.minecraft.recipe.RecipeSerializer;
 import net.minecraft.recipe.RecipeType;
 import net.minecraft.registry.DynamicRegistryManager;
-import net.minecraft.util.Identifier;
-import net.minecraft.util.collection.DefaultedList;
 import net.minecraft.world.World;
 
 public class MortarRecipe implements Recipe<Inventory> {
-	private final Identifier id;
 	final Ingredient input;
 	final ItemStack output;
 	final int damage;
 
-	public MortarRecipe(Identifier id, Ingredient input, ItemStack output, int damage) {
-		this.id = id;
+	public MortarRecipe(Ingredient input, ItemStack output, int damage) {
 		this.input = input;
 		this.output = output;
 		this.damage = damage;
@@ -41,7 +37,7 @@ public class MortarRecipe implements Recipe<Inventory> {
 	}
 
 	@Override
-	public ItemStack getOutput(DynamicRegistryManager registryManager) {
+	public ItemStack getResult(DynamicRegistryManager registryManager) {
 		return this.output;
 	}
 
@@ -54,11 +50,6 @@ public class MortarRecipe implements Recipe<Inventory> {
 	}
 	public boolean canDamage() {
 		return this.damage > 0;
-	}
-
-	@Override
-	public Identifier getId() {
-		return this.id;
 	}
 
 	@Override

--- a/src/main/java/net/luckius/luckius_mortar/recipe/mortar/MortarRecipeSerializer.java
+++ b/src/main/java/net/luckius/luckius_mortar/recipe/mortar/MortarRecipeSerializer.java
@@ -1,75 +1,34 @@
 package net.luckius.luckius_mortar.recipe.mortar;
 
-import com.google.gson.JsonObject;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.recipe.Ingredient;
 import net.minecraft.recipe.RecipeSerializer;
 import net.minecraft.registry.Registries;
-import net.minecraft.util.Identifier;
-import net.minecraft.util.JsonHelper;
 
 public class MortarRecipeSerializer implements RecipeSerializer<MortarRecipe> {
+	// TODO: standardize result format to standard output format and use ItemStack.RECIPE_RESULT_CODEC
+	Codec<MortarRecipe> CODEC = RecordCodecBuilder.create(instance->instance.group(
+			Ingredient.DISALLOW_EMPTY_CODEC.fieldOf("ingredient").forGetter(MortarRecipe::getInput),
+			Registries.ITEM.createEntryCodec().fieldOf("result").forGetter(recipe->recipe.output.getRegistryEntry()),
+			Codec.INT.optionalFieldOf("count",1).forGetter(recipe->recipe.output.getCount()),
+			Codec.INT.optionalFieldOf("damage",0).forGetter(MortarRecipe::getDamage)
+	).apply(instance,(ingredient,result,count,damage)->new MortarRecipe(ingredient,new ItemStack(result,count),Math.max(damage,0))));
+
 	@Override
-	public MortarRecipe read(Identifier id, JsonObject json) {
-		// Gets the object specified by the "input" key
-		var inputObject = json.getAsJsonObject("ingredient");
-		// Helper method to read Ingredient from JsonElement
-		var input = Ingredient.fromJson(inputObject);
-		// Gets the string in the "output" key
-		var outputIdentifier = json.get("result").getAsString();
-		// Gets the integer in the "count" key, fallbacking to 1 if it does not exist
-		var count = JsonHelper.getInt(json, "count", 1);
-		// Attempts to get the item in "output" with the registry and creates a stack with it
-		var output = new ItemStack(Registries.ITEM.getOrEmpty(new Identifier(outputIdentifier))
-				.orElseThrow(() -> new IllegalStateException("Item " + outputIdentifier + " does not exist")), count);
-		var damage = JsonHelper.getInt(json, "damage", 0);
-
-		return new MortarRecipe(id, input, output, Math.max(0, damage));
-	}
-
-
-	/*public JsonObject toJson(MortarRecipe recipe) {
-		var obj = new JsonObject();
-		// Puts the serialized ingredient json element into the "input" key
-		obj.add("ingredient", recipe.input.toJson());
-		// Checks if the output count is higher than the default, and if it is, adds into the "count" key
-		if (recipe.output.getCount() > 1) {
-			obj.addProperty("count", recipe.output.getCount());
-		}
-		// Gets the output identifier from the registry and adds it into the "output" key
-		obj.addProperty("result", Registries.ITEM.getId(recipe.output.getItem()).toString());
-
-		obj.addProperty("damage", Math.max(0, recipe.damage));
-
-		return obj;
+	public Codec<MortarRecipe> codec() {
+		return CODEC;
 	}
 
 	@Override
-	public MortarRecipe read(Identifier id, JsonObject json) {
-		// Gets the object specified by the "input" key
-		var inputObject = json.getAsJsonObject("ingredient");
-		// Helper method to read Ingredient from JsonElement
-		var input = Ingredient.fromJson(inputObject);
-		// Gets the string in the "output" key
-		var outputIdentifier = json.get("result").getAsString();
-		// Gets the integer in the "count" key, fallbacking to 1 if it does not exist
-		var count = JsonHelper.getInt(json, "count", 1);
-		// Attempts to get the item in "output" with the registry and creates a stack with it
-		var output = new ItemStack(Registries.ITEM.getOrEmpty(new Identifier(outputIdentifier))
-				.orElseThrow(() -> new IllegalStateException("Item " + outputIdentifier + " does not exist")), count);
-		var damage = JsonHelper.getInt(json, "damage", 0);
-
-		return new MortarRecipe(id, input, output, Math.max(0, damage));
-	}*/
-
-	@Override
-	public MortarRecipe read(Identifier id, PacketByteBuf buf) {
+	public MortarRecipe read(PacketByteBuf buf) {
 		var input = Ingredient.fromPacket(buf);
 		var output = buf.readItemStack();
 		var damage = buf.readInt();
 
-		return new MortarRecipe(id, input, output, damage);
+		return new MortarRecipe(input, output, damage);
 	}
 
 	@Override


### PR DESCRIPTION
### **Version changes:**

Update Minecraft to 1.20.4
Update Gradle Wrapper to 8.5
Update Loom to 1.5
Update loader to 0.15.6
Update emi to 1.1.0
update Fabric api to 0.95.4

### **Code changes:**

Now passes RecipeEntry instead of Recipe directly. This moves id out of the recipe itself.

Rename getOutput to getResult to match yarn naming

Codec creation. 
* In the future it would be prudent to go back to standard recipe formatting with the output rather than custom since there are no extra fields.